### PR TITLE
fix: use sub command for gitleaks

### DIFF
--- a/.github/workflows/test-secret.yml
+++ b/.github/workflows/test-secret.yml
@@ -43,5 +43,5 @@ jobs:
       - name: Run gitleaks
         run: |
           base_sha=$(git merge-base origin/main HEAD)
-          docker run --rm -v "$(pwd)":/work -w /work zricethezav/gitleaks --path=/work -v --redact \
-          --commit-to="${base_sha}"
+          docker run --rm -v "$(pwd)":/work -w /work zricethezav/gitleaks detect --source=/work -v --redact \
+          --log-opts="${base_sha}..HEAD"

--- a/.github/workflows/test-secret.yml
+++ b/.github/workflows/test-secret.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Install gitleaks
         run: docker pull zricethezav/gitleaks
       - name: Display gitleaks
-        run: docker run --rm zricethezav/gitleaks --version
+        run: docker run --rm zricethezav/gitleaks version
       - name: Fetch base branch
         run: git fetch --no-tags --depth=1 origin main
       - name: Run gitleaks


### PR DESCRIPTION
## Error messages

```shell
  docker run --rm zricethezav/gitleaks --version
  shell: /usr/bin/bash -e {0}
Error: unknown flag: --version
```

```shell
  docker run --rm -v "$(pwd)":/work -w /work zricethezav/gitleaks --path=/work -v --redact \
  --commit-to="${base_sha}"
  shell: /usr/bin/bash -e {0}
Error: unknown flag: --path
```